### PR TITLE
Adds support for step based logging

### DIFF
--- a/examples/pipeline-complex/main.py
+++ b/examples/pipeline-complex/main.py
@@ -3,7 +3,7 @@ import json
 
 import nextmv
 
-from nextpipe import FlowSpec, app, needs, repeat, step
+from nextpipe import FlowSpec, app, log, needs, repeat, step
 
 
 # >>> Workflow definition
@@ -26,21 +26,21 @@ class Flow(FlowSpec):
         return clone
 
     @repeat(repetitions=2)
-    @app(app_id="routing-nextroute")
+    @app(app_id="routing-nextroute", instance_id="latest")
     @needs(predecessors=[prepare])
     @step
     def run_nextroute():
         """Runs the model."""
         pass
 
-    @app(app_id="routing-ortools")
+    @app(app_id="routing-ortools", instance_id="latest")
     @needs(predecessors=[convert])
     @step
     def run_ortools():
         """Runs the model."""
         pass
 
-    @app(app_id="routing-pyvroom")
+    @app(app_id="routing-pyvroom", instance_id="latest")
     @needs(predecessors=[convert])
     @step
     def run_pyvroom():
@@ -63,7 +63,7 @@ class Flow(FlowSpec):
 
         values = [result["statistics"]["result"]["value"] for result in results]
         values.sort()
-        nextmv.log(f"Values: {values}")
+        log(f"Values: {values}")
 
         # For test stability reasons, we always return the or-tools result
         _ = results.pop(best_solution_idx)

--- a/examples/pipeline-preprocess/main.py
+++ b/examples/pipeline-preprocess/main.py
@@ -3,9 +3,8 @@ import json
 
 import nextmv.cloud
 import requests
-from nextmv.logger import log
 
-from nextpipe import FlowSpec, app, needs, repeat, step
+from nextpipe import FlowSpec, app, log, needs, repeat, step
 
 
 # >>> Workflow definition

--- a/nextpipe/__init__.py
+++ b/nextpipe/__init__.py
@@ -12,6 +12,7 @@ from .flow import FlowGraph as FlowGraph
 from .flow import FlowSpec as FlowSpec
 from .schema import AppOption as AppOption
 from .schema import AppRunConfig as AppRunConfig
+from .utils import log as log
 
 VERSION = __version__
 """The version of the nextpipe package."""

--- a/nextpipe/decorators.py
+++ b/nextpipe/decorators.py
@@ -79,9 +79,9 @@ class Step:
 def step(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
-        utils.log(f"Entering {function.__name__}")
+        utils.log_internal(f"Entering {function.__name__}")
         ret_val = function(*args, **kwargs)
-        utils.log(f"Finished {function.__name__}")
+        utils.log_internal(f"Finished {function.__name__}")
         return ret_val
 
     wrapper.step = Step(function)
@@ -207,7 +207,7 @@ def app(
     def decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            utils.log(f"Running {app_id} version {instance_id}")
+            utils.log_internal(f"Running {app_id} version {instance_id}")
             return function(*args, **kwargs)
 
         # We need to make sure that all values of the parameters are converted to strings,

--- a/nextpipe/flow.py
+++ b/nextpipe/flow.py
@@ -104,10 +104,10 @@ class FlowGraph:
         self.__debug_print()
         # Create a Mermaid diagram of the graph and log it
         mermaid = self._to_mermaid()
-        utils.log("Mermaid diagram:")
-        utils.log(mermaid)
+        utils.log_internal("Mermaid diagram:")
+        utils.log_internal(mermaid)
         mermaid_url = f"https://mermaid.ink/svg/{base64.b64encode(mermaid.encode('utf8')).decode('ascii')}?theme=dark"
-        utils.log(f"Mermaid URL: {mermaid_url}")
+        utils.log_internal(f"Mermaid URL: {mermaid_url}")
 
     def get_step(self, definition: decorators.Step) -> FlowStep:
         return self.steps_by_definition[definition]
@@ -209,14 +209,14 @@ class FlowGraph:
         )
 
     def __debug_print(self):
-        utils.log(f"Flow: {self.flow_spec_type.__name__}")
-        utils.log(f"nextpipe: {version('nextpipe')}")
-        utils.log(f"nextmv: {version('nextmv')}")
-        utils.log("Flow graph steps:")
+        utils.log_internal(f"Flow: {self.flow_spec_type.__name__}")
+        utils.log_internal(f"nextpipe: {version('nextpipe')}")
+        utils.log_internal(f"nextmv: {version('nextmv')}")
+        utils.log_internal("Flow graph steps:")
         for step in self.steps:
-            utils.log("Step:")
-            utils.log(f"  Definition: {step.definition}")
-            utils.log(f"  Docstring: {step.docstring}")
+            utils.log_internal("Step:")
+            utils.log_internal(f"  Definition: {step.definition}")
+            utils.log_internal(f"  Docstring: {step.docstring}")
 
 
 class StepVisitor(ast.NodeVisitor):
@@ -323,7 +323,7 @@ class Runner:
 
     @staticmethod
     def __run_step(node: FlowNode, inputs: list[object], client: Client) -> Union[list[object], object, None]:
-        utils.log(f"Running node {node.id}")
+        utils.log_internal(f"Running node {node.id}")
 
         # Run the step
         if node.parent.definition.is_app():
@@ -384,6 +384,7 @@ class Runner:
             target=self.__run_step,
             callback=self.__node_callback,
             args=(node, inputs, self.spec.client),
+            name=utils.THREAD_NAME_PREFIX + node.id,
             reference=node,
         )
 
@@ -394,7 +395,7 @@ class Runner:
             self.uplink.run_async()
         except Exception as e:
             self.uplink.terminate()
-            utils.log(f"Failed to update graph with platform: {e}")
+            utils.log_internal(f"Failed to update graph with platform: {e}")
 
         # Start running the flow
         open_steps: set[FlowStep] = set(self.graph.start_steps)
@@ -406,7 +407,7 @@ class Runner:
             # If there was a failure, stop running the flow
             with self.lock_fail:
                 if self.fail:
-                    utils.log(f"Flow failed: {self.fail_reason}")
+                    utils.log_internal(f"Flow failed: {self.fail_reason}")
                     break
             while True:
                 # Get the first step from the open steps which has all its predecessors done
@@ -417,7 +418,7 @@ class Runner:
                 open_steps.remove(step)
                 # Skip the step if it is optional and the condition is not met
                 if step.definition.skip():
-                    utils.log(f"Skipping step {step.definition.get_id()}")
+                    utils.log_internal(f"Skipping step {step.definition.get_id()}")
                     step.definition.set_state("skipped")
                     # Create dummy node
                     node = FlowNode(step, 0)

--- a/nextpipe/threads.py
+++ b/nextpipe/threads.py
@@ -3,6 +3,8 @@ import threading
 import traceback
 from typing import Callable, Optional
 
+thread_local = threading.local()
+
 
 class Job:
     def __init__(
@@ -10,11 +12,13 @@ class Job:
         target: Callable,
         callback: Callable,
         args: Optional[list] = None,
+        name: str = None,
         reference: any = None,
     ):
         self.target = target
         self.callback = callback
         self.args = args
+        self.name = name
         self.reference = reference
         self.done = False
         self.result = None
@@ -64,7 +68,10 @@ class Pool:
             with self.lock:
                 if len(self.running) < self.max_threads:
                     # Move job from waiting to running
-                    thread = threading.Thread(target=worker, args=(job, thread_id))
+                    kw_args = {"target": worker, "args": (job, thread_id)}
+                    if job.name:
+                        kw_args["name"] = job.name
+                    thread = threading.Thread(**kw_args)
                     self.running[thread_id] = thread
                     self.waiting.pop(thread_id, None)
                     thread.start()

--- a/nextpipe/uplink.py
+++ b/nextpipe/uplink.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from nextmv.cloud import Client
 
-from nextpipe.utils import log
+from nextpipe.utils import log_internal
 
 FAILED_UPDATES_THRESHOLD = 10
 
@@ -104,7 +104,7 @@ class UplinkClient:
         if not self.config.application_id or not self.config.run_id:
             self.inactive = True
             self.terminated = True
-            log("No application ID or run ID found, uplink is inactive.")
+            log_internal("No application ID or run ID found, uplink is inactive.")
         self.client = client
         self._lock = threading.Lock()
         self.node_state = {}

--- a/nextpipe/utils.py
+++ b/nextpipe/utils.py
@@ -1,14 +1,38 @@
 import sys
+import threading
 import time
 from functools import wraps
 
 from nextmv.cloud import Application, RunResult, StatusV2
 
+THREAD_NAME_PREFIX = "nextpipe-"
+
+
+def __get_step_name() -> str:
+    """
+    Gets the name of the step currently executing in the calling thread.
+    """
+    if threading.current_thread().name.startswith(THREAD_NAME_PREFIX):
+        return threading.current_thread().name[len(THREAD_NAME_PREFIX) :]
+    return "nextpipe"
+
 
 def log(message: str) -> None:
-    """Logs a message using stderr."""
+    """
+    Logs a message using stderr. Furthermore, prepends the name of the calling function if it is a step.
+    """
+    step_name = __get_step_name()
+    if step_name:
+        print(f"[{step_name}] {message}", file=sys.stderr)
+    else:
+        print(message, file=sys.stderr)
 
-    print(message, file=sys.stderr)
+
+def log_internal(message: str) -> None:
+    """
+    Logs a message using stderr.
+    """
+    print(f"[nextpipe] {message}", file=sys.stderr)
 
 
 def wrap_func(function):

--- a/nextpipe/utils.py
+++ b/nextpipe/utils.py
@@ -14,7 +14,7 @@ def __get_step_name() -> str:
     """
     if threading.current_thread().name.startswith(THREAD_NAME_PREFIX):
         return threading.current_thread().name[len(THREAD_NAME_PREFIX) :]
-    return "nextpipe"
+    return "main"
 
 
 def log(message: str) -> None:

--- a/tests/pipelines/complex.py
+++ b/tests/pipelines/complex.py
@@ -2,7 +2,7 @@ import json
 
 import nextmv
 
-from nextpipe import FlowSpec, app, needs, repeat, step
+from nextpipe import FlowSpec, app, log, needs, repeat, step
 
 
 # >>> Workflow definition
@@ -50,7 +50,7 @@ class Flow(FlowSpec):
 
         values = [result["statistics"]["result"]["value"] for result in results]
         values.sort()
-        nextmv.log(f"Values: {values}")
+        log(f"Values: {values}")
 
         # For test stability reasons, we always return the or-tools result
         _ = results.pop(best_solution_idx)


### PR DESCRIPTION
# Description

Adds a nextpipe specific log function that makes it easier to identify from which step (or rather it's node being executed) a log statement was issued.

When using this log function the log will look like this:

```txt
[main] Running the workflow.
[nextpipe] No application ID or run ID found, uplink is inactive.
[nextpipe] Flow: Flow
[nextpipe] nextpipe: 0.1.0.dev5
[nextpipe] nextmv: 0.18.1
[nextpipe] Flow graph steps:
[nextpipe] Step:
[nextpipe]   Definition: Step(prepare)
[nextpipe]   Docstring: Prepares the data.
[nextpipe] Step:
[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, devint, {}, InputType.JSON, False))
[nextpipe]   Docstring: Runs the model.
[nextpipe] Step:
[nextpipe]   Definition: Step(enhance, StepNeeds(solve))
[nextpipe]   Docstring: Enhances the result.
[nextpipe] Mermaid diagram:
[nextpipe] graph LR
  prepare(prepare)
  prepare --> solve
  solve(solve)
  solve --> enhance
  enhance(enhance)

[nextpipe] Mermaid URL: https://mermaid.ink/svg/Z3JhcGggTFIKICBwcmVwYXJlKHByZXBhcmUpCiAgcHJlcGFyZSAtLT4gc29sdmUKICBzb2x2ZShzb2x2ZSkKICBzb2x2ZSAtLT4gZW5oYW5jZQogIGVuaGFuY2UoZW5oYW5jZSkK?theme=dark
[nextpipe] Running node prepare_0
[prepare_0] Preparing the data.
[nextpipe] Running node solve_0
[nextpipe] Running node enhance_0
[enhance_0] Enhancing the result.
```

Note the `[main]` for a case where the log function is used outside the context of a step and note the `[enhance_0]` & `[prepare_0]` for using it in the enhance and prepare steps respectively. All `[nextpipe]` mark log messages issued by _nextpipe_ itself.

(This is based on the chain example in _./examples/chain_ with added logging)

## Changes

- Adds `log(msg)` function for more granular and context-aware logging within the workflow steps. This function automatically prefixes log messages with the name of the step (or node) being executed, making it easier to trace the origin of log statements in complex workflows.