### PR TITLE
Fixes error handling, adds jitter to app run wait

### DIFF
--- a/nextpipe/flow.py
+++ b/nextpipe/flow.py
@@ -404,11 +404,6 @@ class Runner:
 
         # Run the steps in parallel
         while open_steps or running_steps:
-            # If there was a failure, stop running the flow
-            with self.lock_fail:
-                if self.fail:
-                    utils.log_internal(f"Flow failed: {self.fail_reason}")
-                    break
             while True:
                 # Get the first step from the open steps which has all its predecessors done
                 step = next(iter(filter(lambda n: all(p in closed_steps for p in n.predecessors), open_steps)), None)
@@ -456,3 +451,7 @@ class Runner:
                         running_steps.remove(step)
                     closed_steps.add(step)
                     open_steps.update(step.successors)
+                # Raise an exception if the flow failed
+                with self.lock_fail:
+                    if self.fail:
+                        raise RuntimeError(f"Flow failed: {self.fail_reason}")

--- a/nextpipe/threads.py
+++ b/nextpipe/threads.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import threading
-import traceback
 from typing import Callable, Optional
 
 thread_local = threading.local()
@@ -40,6 +39,7 @@ class Pool:
         self.counter = 0  # Used to assign unique IDs to threads
         self.waiting = {}
         self.running = {}
+        self.error = None
         self.lock = threading.Lock()
         self.cond = threading.Condition(self.lock)
 
@@ -56,7 +56,8 @@ class Pool:
             try:
                 job.run()
             except Exception as e:
-                job.error = f"Error in thread {thread_id}: {e}\n{traceback.format_exc()}"
+                job.error = e
+                raise RuntimeError(f"Error in thread {thread_id}: {e}") from e
             finally:
                 with self.lock:
                     self.running.pop(thread_id, None)

--- a/nextpipe/utils.py
+++ b/nextpipe/utils.py
@@ -70,7 +70,7 @@ def wait_for_runs(
     # Wait until all runs are finished or the timeout is reached
     jitter = random.random() * 2.0
     missing = set(run_ids)
-    backoff = 1.0 + jitter  # With base and jitter we aim for a backoff start between 1 and 3 seconds
+    backoff = 2.0 + jitter  # With base and jitter we aim for a backoff start between 2 and 4 seconds
     start_time = time.time()
     while missing and time.time() - start_time < timeout:
         time.sleep(backoff)

--- a/nextpipe/utils.py
+++ b/nextpipe/utils.py
@@ -1,3 +1,4 @@
+import random
 import sys
 import threading
 import time
@@ -67,8 +68,9 @@ def wait_for_runs(
     Wait until all runs with the given IDs are finished.
     """
     # Wait until all runs are finished or the timeout is reached
+    jitter = random.random() * 2.0
     missing = set(run_ids)
-    backoff = 2
+    backoff = 1.0 + jitter  # With base and jitter we aim for a backoff start between 1 and 3 seconds
     start_time = time.time()
     while missing and time.time() - start_time < timeout:
         time.sleep(backoff)

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -38,14 +38,13 @@ class TestLogger(unittest.TestCase):
                 intercepted_exception = job.error
 
         pool = Pool(2)
-        for i in range(1, 2):  # Submit 1
+        for i in range(1, 2):
             pool.run(Job(target, callback, (i,)))
         pool.join()
 
         self.assertIsNotNone(intercepted_exception)
-        self.assertIsInstance(intercepted_exception, str)
-        self.assertTrue(intercepted_exception.startswith("Error in thread"))
-        self.assertIn("ValueError: Something went wrong", intercepted_exception)
+        self.assertIsInstance(intercepted_exception, ValueError)
+        self.assertEqual(str(intercepted_exception), "Something went wrong")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR fixes an issue in error handling and aims to improve app run status polls.

## Changes

- Fixes an issue where an exception occurring in the last step would not get elevated correctly.
- Raises the exception instead of just logging it from now on.
- Adds jitter to status polls.

Resolves ENG-5839