### PR TITLE
Aligns nextmv write_local, fixes preprocess example

### DIFF
--- a/examples/pipeline-chain/main.py
+++ b/examples/pipeline-chain/main.py
@@ -1,5 +1,3 @@
-import json
-
 import nextmv
 
 from nextpipe import FlowSpec, app, needs, step
@@ -38,7 +36,7 @@ def main():
     flow.run()
 
     # Write out the result
-    print(json.dumps(flow.get_result(flow.enhance)))
+    nextmv.write_local(flow.get_result(flow.enhance))
 
 
 if __name__ == "__main__":

--- a/examples/pipeline-complex/main.py
+++ b/examples/pipeline-complex/main.py
@@ -1,5 +1,4 @@
 import copy
-import json
 
 import nextmv
 
@@ -77,8 +76,7 @@ def main():
     # Run workflow
     flow = Flow("DecisionFlow", input.data)
     flow.run()
-    result = flow.get_result(flow.pick_best)
-    print(json.dumps(result))
+    nextmv.write_local(flow.get_result(flow.pick_best))
 
 
 if __name__ == "__main__":

--- a/examples/pipeline-ensemble/main.py
+++ b/examples/pipeline-ensemble/main.py
@@ -1,5 +1,3 @@
-import json
-
 import nextmv
 
 from nextpipe import FlowSpec, app, log, needs, repeat, step
@@ -43,8 +41,7 @@ def main():
     # Run workflow
     flow = Flow("DecisionFlow", input.data)
     flow.run()
-    result = flow.get_result(flow.pick_best)
-    print(json.dumps(result))
+    nextmv.write_local(flow.get_result(flow.pick_best))
 
 
 if __name__ == "__main__":

--- a/examples/pipeline-foreach/main.py
+++ b/examples/pipeline-foreach/main.py
@@ -56,7 +56,7 @@ def main():
     flow.run()
 
     # Write out the result
-    print(json.dumps(flow.get_result(flow.merge)))
+    nextmv.write_local(flow.get_result(flow.merge))
 
 
 if __name__ == "__main__":

--- a/examples/pipeline-preprocess/main.py
+++ b/examples/pipeline-preprocess/main.py
@@ -22,38 +22,36 @@ class Flow(FlowSpec):
     def convert(input_csv: str):
         reader = csv.reader(input_csv.splitlines())
         next(reader)  # skip header
-        return json.dumps(
-            {
-                "vehicles": [
-                    {
-                        "id": f"vehicle-{i}",
-                        "start_location": {"lon": 7.62558, "lat": 51.96223},
-                        "end_location": {"lon": 7.62558, "lat": 51.96223},
-                        "start_time": "2024-09-04T11:00:00+00:00",
-                        "speed": 10,
-                        "capacity": 27,
-                    }
-                    for i in range(20)
-                ],
-                "stops": [
-                    {
-                        "id": row[0],
-                        "location": {"lon": float(row[1]), "lat": float(row[2])},
-                        "quantity": -1,
-                        "unplanned_penalty": 2000000000,
-                    }
-                    for row in reader
-                ],
-            }
-        )
+        return {
+            "vehicles": [
+                {
+                    "id": f"vehicle-{i}",
+                    "start_location": {"lon": 7.62558, "lat": 51.96223},
+                    "end_location": {"lon": 7.62558, "lat": 51.96223},
+                    "start_time": "2024-09-04T11:00:00+00:00",
+                    "speed": 10,
+                    "capacity": 27,
+                }
+                for i in range(20)
+            ],
+            "stops": [
+                {
+                    "id": row[0],
+                    "location": {"lon": float(row[1]), "lat": float(row[2])},
+                    "quantity": -1,
+                    "unplanned_penalty": 2000000000,
+                }
+                for row in reader
+            ],
+        }
 
     @needs(predecessors=[convert])
     @step
     def align(input: dict):
-        clone = json.loads(input)
+        clone = json.loads(json.dumps(input))
         for stop in [s for s in clone["stops"] if "quantity" in s]:
             stop["quantity"] *= -1
-        return json.dumps(clone)
+        return clone
 
     # >>> Solve the problem using different solvers
     @app(
@@ -104,7 +102,7 @@ def main():
     flow.run()
 
     # Write out the result
-    print(json.dumps(flow.get_result(flow.pick_best)))
+    nextmv.write_local(flow.get_result(flow.pick_best))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR makes the pipeline examples adhere to the canonical way of writing out results using the `nextmv.write_local` function. Furthermore, it fixes an issue with the `pipeline-preprocess` example.

### Refactoring for result handling:

* Replaced `print(json.dumps(...))` with `nextmv.write_local(...)` for writing results in the `main()` functions of all examples.
* Fixes `pipeline-preprocess` example by using dicts directly.