### PR TITLE
Adds support for key/value dicts in 'AppRunConfig' options

### DIFF
--- a/docs/tutorials/echo.md
+++ b/docs/tutorials/echo.md
@@ -4,7 +4,7 @@ Several examples assume you have a Nextmv application called `echo`. This is
 just a simple application created for demonstration purposes. It takes the
 input and echoes it with some minor modifications.
 
-Let’s get set up with the `echo` application. Before starting:
+Let's get set up with the `echo` application. Before starting:
 
 1. [Sign up][signup] for a Nextmv account.
 2. Get your API key. Go to [Team > API Key][api-key].
@@ -15,7 +15,7 @@ Make sure that you have your API key set as an environment variable:
 export NEXTMV_API_KEY="<YOUR-API-KEY>"
 ```
 
-Now that you have a valid Nextmv account and API key, let’s create the `echo`
+Now that you have a valid Nextmv account and API key, let's create the `echo`
 Nextmv app.
 
 1. In a new directory, create a file called `main.py` with the code for the

--- a/nextpipe/decorators.py
+++ b/nextpipe/decorators.py
@@ -114,7 +114,7 @@ class Step:
         The IDs of the runs associated with this step.
     _inputs : dict
         The inputs to the step.
-    _output : any
+    _output : Any
         The output of the step.
     """
 
@@ -298,7 +298,7 @@ def step(function):
     from nextpipe import step
     ```
 
-    This is the most basic decorator. This decorator doesn’t require any
+    This is the most basic decorator. This decorator doesn't require any
     parameters or the use of parentheses.
 
     Example
@@ -647,7 +647,7 @@ def foreach(f: Callable = None):
     class Flow(FlowSpec):
         @foreach()
         @step
-        def step1() -> list[dict[str, any]]:
+        def step1() -> list[dict[str, Any]]:
             return [{"input": 1}, {"input": 2}, {"input": 3}]
 
         @needs(predecessors=[step1])
@@ -722,17 +722,17 @@ def join(f: Callable = None):
 
     class Flow(FlowSpec):
         @step
-        def step1() -> dict[str, any]:
+        def step1() -> dict[str, Any]:
             return {"input": 1}
 
         @step
-        def step2() -> dict[str, any]:
+        def step2() -> dict[str, Any]:
             return {"input": 2}
 
         @join()
         @needs(predecessors=[step1, step2])
         @step
-        def step3(data: list[dict[str, any]]) -> None:
+        def step3(data: list[dict[str, Any]]) -> None:
             log(data)
 
 
@@ -770,7 +770,7 @@ class App:
         The ID of the Nextmv Application to run.
     instance_id : str
         The ID of the instance to run.
-    options : dict[str, any]
+    options : dict[str, Any]
         The options to pass to the application.
     input_type : InputType
         The type of input to pass to the application (JSON or FILES).
@@ -785,8 +785,8 @@ class App:
         app_id: str,
         instance_id: str = "devint",
         input_type: InputType = InputType.JSON,
-        parameters: dict[str, any] = None,
-        options: dict[str, any] = None,
+        parameters: dict[str, typing.Any] = None,
+        options: dict[str, typing.Any] = None,
         full_result: bool = False,
         polling_options: typing.Optional[cloud.PollingOptions] = _DEFAULT_POLLING_OPTIONS,
     ):
@@ -801,7 +801,7 @@ class App:
             The ID of the instance to run, by default "devint".
         input_type : InputType, optional
             The type of input to pass to the application, by default InputType.JSON.
-        options : dict[str, any], optional
+        options : dict[str, Any], optional
             The options to pass to the application, by default None.
         full_result : bool, optional
             Whether to return the full result including metadata, by default False.
@@ -841,8 +841,8 @@ class App:
 def app(
     app_id: str,
     instance_id: str = "devint",
-    parameters: dict[str, any] = None,
-    options: dict[str, any] = None,
+    parameters: dict[str, typing.Any] = None,
+    options: dict[str, typing.Any] = None,
     input_type: InputType = InputType.JSON,
     full_result: bool = False,
     polling_options: typing.Optional[cloud.PollingOptions] = _DEFAULT_POLLING_OPTIONS,
@@ -868,7 +868,7 @@ def app(
         The ID of the application to run.
     instance_id : str
         The ID of the instance to run. Default is "devint".
-    options : dict[str, any]
+    options : dict[str, Any]
         The options to pass to the application. This is a dictionary of
         parameter names and values. The values must be JSON serializable.
     input_type : InputType
@@ -900,7 +900,7 @@ def app(
 
     class Flow(FlowSpec):
         @step
-        def pre_process(input: dict[str, any]) -> dict[str, any]:
+        def pre_process(input: dict[str, Any]) -> dict[str, Any]:
             log("You can pre-process your data here.")
             return input
 
@@ -912,7 +912,7 @@ def app(
 
         @needs(predecessors=[solve])
         @step
-        def post_process(result: dict[str, any]) -> dict[str, any]:
+        def post_process(result: dict[str, Any]) -> dict[str, Any]:
             log("You can post-process your data here.")
             return result
 

--- a/nextpipe/flow.py
+++ b/nextpipe/flow.py
@@ -919,7 +919,7 @@ class Runner:
                 app_run_config: schema.AppRunConfig = inputs[0]
                 input = app_run_config.input
                 name = app_run_config.name if app_run_config.name else node.id
-                app_run_options = {option.name: option.value for option in app_run_config.options}
+                app_run_options = app_run_config.get_options()
                 # Merge the options from the app decorator with the options from the
                 # AppRunConfig. AppRunConfig options take precedence.
                 options = app_step.options | app_run_options

--- a/nextpipe/flow.py
+++ b/nextpipe/flow.py
@@ -188,7 +188,7 @@ class FlowNode:
         self.error: str = None
         self.predecessors: list[FlowNode] = []
         self.run_id: str = None
-        self.result: any = None
+        self.result: Any = None
         self.done: bool = False
         self.cancel: bool = False
 
@@ -932,7 +932,7 @@ class Runner:
             # Modify the polling options set for the step (by default or by the
             # user) so that the initial delay is randomized and the stopping
             # callback is configured as the node being cancelled if the user
-            # doesn’t want to override it.
+            # doesn't want to override it.
             polling_options = copy.deepcopy(app_step.polling_options)
             delay = random.uniform(0, 5)  # For lack of a better idea...
             polling_options.initial_delay = delay

--- a/nextpipe/schema.py
+++ b/nextpipe/schema.py
@@ -92,3 +92,19 @@ class AppRunConfig:
     """Options for running the app."""
     name: Optional[str] = None
     """Name for the run."""
+
+    def get_options(self) -> dict[str, Any]:
+        """
+        Get options as a dictionary.
+
+        This method converts the `options` attribute to a dictionary if it is provided
+        as a list of `AppOption` instances.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary of options.
+        """
+        if isinstance(self.options, list):
+            return {option.name: option.value for option in self.options}
+        return self.options

--- a/nextpipe/schema.py
+++ b/nextpipe/schema.py
@@ -12,7 +12,7 @@ AppRunConfig
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional, Union
 
 from dataclasses_json import dataclass_json
 
@@ -36,7 +36,7 @@ class AppOption:
     ----------
     name : str
         Key for the option.
-    value : any
+    value : Any
         Value for the option.
 
     Examples
@@ -47,7 +47,7 @@ class AppOption:
 
     name: str
     """Key for the option."""
-    value: any
+    value: Any
     """Value for the option."""
 
 
@@ -68,10 +68,11 @@ class AppRunConfig:
 
     Parameters
     ----------
-    input : dict[str, any], optional
+    input : dict[str, Any], optional
         Input data for the app, by default None.
-    options : list[AppOption], optional
-        Options for running the app, by default an empty list.
+    options : Union[list[AppOption], dict[str, Any]], optional
+        Options for running the app, by default empty. These can be provided as a list of
+        `AppOption` instances, or, simply as a dictionary of key-value pairs.
     name : str, optional
         Name for the run, by default None.
 
@@ -85,9 +86,9 @@ class AppRunConfig:
     ... )
     """
 
-    input: dict[str, any] = None
+    input: dict[str, Any] = None
     """Input for the app."""
-    options: list[AppOption] = field(default_factory=list)
+    options: Union[list[AppOption], dict[str, Any]] = field(default_factory=list)
     """Options for running the app."""
     name: Optional[str] = None
     """Name for the run."""

--- a/nextpipe/schema.py
+++ b/nextpipe/schema.py
@@ -16,6 +16,8 @@ from typing import Any, Optional, Union
 
 from dataclasses_json import dataclass_json
 
+from . import utils
+
 
 @dataclass_json
 @dataclass
@@ -81,7 +83,7 @@ class AppRunConfig:
     >>> from nextpipe import AppRunConfig, AppOption
     >>> config = AppRunConfig(
     ...     input={"data": [1, 2, 3]},
-    ...     options=[AppOption(name="threads", value=4)],
+    ...     options={"threads": 4},
     ...     name="my-run"
     ... )
     """
@@ -105,6 +107,8 @@ class AppRunConfig:
         dict[str, Any]
             Dictionary of options.
         """
+        options = self.options
         if isinstance(self.options, list):
-            return {option.name: option.value for option in self.options}
-        return self.options
+            options = {option.name: option.value for option in self.options}
+        options = utils.convert_to_string_values(options)
+        return options

--- a/nextpipe/threads.py
+++ b/nextpipe/threads.py
@@ -16,7 +16,7 @@ The module also provides a thread local storage variable for thread-specific dat
 import multiprocessing
 import threading
 from collections.abc import Callable
-from typing import Optional
+from typing import Any, Optional
 
 thread_local = threading.local()
 """Thread-local storage.
@@ -45,7 +45,7 @@ class Job:
         Arguments to be passed to the target function, by default None.
     name : str, optional
         Name for the job, by default None.
-    reference : any, optional
+    reference : Any, optional
         Reference to any object associated with this job, by default None.
 
     Attributes
@@ -60,11 +60,11 @@ class Job:
         Arguments to be passed to the target function.
     name : str
         Name for the job.
-    reference : any
+    reference : Any
         Reference to any object associated with this job.
     done : bool
         Whether the job has completed.
-    result : any
+    result : Any
         The result of the job execution.
     error : Exception
         Any exception that occurred during job execution.
@@ -93,7 +93,7 @@ class Job:
         done_callback: Callable,
         args: Optional[list] = None,
         name: str = None,
-        reference: any = None,
+        reference: Any = None,
     ):
         self.target = target
         self.start_callback = start_callback
@@ -111,11 +111,6 @@ class Job:
         Executes the target function with the provided arguments (if any)
         and sets the done flag to True. The result of the execution is
         stored in the result attribute.
-
-        Returns
-        -------
-        any
-            The result of the target function execution.
         """
 
         if self.args:

--- a/nextpipe/uplink.py
+++ b/nextpipe/uplink.py
@@ -62,7 +62,7 @@ def ExcludeIfNone(value):
 
     Parameters
     ----------
-    value : any
+    value : Any
         The value to check.
 
     Returns

--- a/nextpipe/utils.py
+++ b/nextpipe/utils.py
@@ -24,6 +24,7 @@ import inspect
 import sys
 import threading
 from functools import wraps
+from typing import Any
 
 THREAD_NAME_PREFIX = "nextpipe-"
 """str: Prefix for thread names created by nextpipe."""
@@ -134,7 +135,7 @@ def wrap_func(function):
     return func_wrapper
 
 
-def convert_to_string_values(input_dict: dict[str, any]) -> dict[str, str]:
+def convert_to_string_values(input_dict: dict[str, Any]) -> dict[str, str]:
     """
     Converts all values of the given dictionary to strings.
 
@@ -143,7 +144,7 @@ def convert_to_string_values(input_dict: dict[str, any]) -> dict[str, str]:
 
     Parameters
     ----------
-    input_dict : dict[str, any]
+    input_dict : dict[str, Any]
         The dictionary with values to convert.
 
     Returns

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,11 +1,21 @@
 import unittest
 
-from nextpipe import AppRunConfig
+from nextpipe import AppOption, AppRunConfig
 
 
 class TestAppRunConfig(unittest.TestCase):
-    def test_options(self):
+    def test_options_dict(self):
         config = AppRunConfig(input={"data": [1, 2, 3]}, options={"threads": 4, "verbose": True}, name="test-run")
+        options = config.get_options()
+        self.assertEqual(options["threads"], "4")
+        self.assertTrue(options["verbose"], "True")
+
+    def test_options_obj(self):
+        config = AppRunConfig(
+            input={"data": [1, 2, 3]},
+            options=[AppOption(name="threads", value=4), AppOption(name="verbose", value=True)],
+            name="test-run",
+        )
         options = config.get_options()
         self.assertEqual(options["threads"], "4")
         self.assertTrue(options["verbose"], "True")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,11 @@
+import unittest
+
+from nextpipe import AppRunConfig
+
+
+class TestAppRunConfig(unittest.TestCase):
+    def test_options(self):
+        config = AppRunConfig(input={"data": [1, 2, 3]}, options={"threads": 4, "verbose": True}, name="test-run")
+        options = config.get_options()
+        self.assertEqual(options["threads"], "4")
+        self.assertTrue(options["verbose"], "True")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,7 @@ class TestAppRunConfig(unittest.TestCase):
         config = AppRunConfig(input={"data": [1, 2, 3]}, options={"threads": 4, "verbose": True}, name="test-run")
         options = config.get_options()
         self.assertEqual(options["threads"], "4")
-        self.assertTrue(options["verbose"], "True")
+        self.assertEqual(options["verbose"], "True")
 
     def test_options_obj(self):
         config = AppRunConfig(


### PR DESCRIPTION
# Description

Adds support for simple key/value-pair dictionaries in `AppRunConfig` options.

I.e., instead of defining options like this:

```python
AppRunConfig(
    input=input,
    options=[
        AppOption("solve.duration", "1600"),
    ],
)
```

It is now also possible to define them like this:

```python
AppRunConfig(
    input=input,
    options={
        "solve.duration":  1600,
    },
)
```

## Changes

- Allows defining options in `AppRunConfig` as a simple key/value dict.
- Fix `Any` type hints.
- Fix single quotes in docs.

Resolves ENG-6114