### PR TITLE
Uses platform defined default instance

### DIFF
--- a/docs/examples/basic-chained-workflow.md
+++ b/docs/examples/basic-chained-workflow.md
@@ -76,7 +76,7 @@ $ echo '{"hello": "world!"}' | python main.py
 [nextpipe]   Definition: Step(prepare)
 [nextpipe]   Docstring: Prepares the data.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, devint, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, latest, {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
 [nextpipe]   Definition: Step(enhance, StepNeeds(solve))

--- a/docs/examples/complex-workflow-csv.md
+++ b/docs/examples/complex-workflow-csv.md
@@ -95,14 +95,14 @@ class Workflow(FlowSpec):
         """Solve the problem using the Nextroute solver."""
         pass
 
-    @app(app_id="routing-pyvroom", instance_id="latest", full_result=True)
+    @app(app_id="routing-pyvroom", full_result=True)
     @needs(predecessors=[align])
     @step
     def solve_vroom() -> dict[str, Any]:
         """Solve the problem using the Vroom solver."""
         pass
 
-    @app(app_id="routing-ortools", instance_id="latest", full_result=True)
+    @app(app_id="routing-ortools", full_result=True)
     @needs(predecessors=[align])
     @step
     def solve_ortools() -> dict[str, Any]:
@@ -166,13 +166,13 @@ $ echo '{}' | python main.py
 [nextpipe]   Definition: Step(align, StepNeeds(convert))
 [nextpipe]   Docstring: Align the input data for the solver.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve_nextroute, StepNeeds(convert), StepRepeat(3), StepRun(routing-nextroute, latest, {'solve.duration': '30s'}, InputType.JSON, True))
+[nextpipe]   Definition: Step(solve_nextroute, StepNeeds(convert), StepRepeat(3), StepRun(routing-nextroute, , {'solve.duration': '30s'}, InputType.JSON, True))
 [nextpipe]   Docstring: Solve the problem using the Nextroute solver.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve_vroom, StepNeeds(align), StepRun(routing-pyvroom, latest, {}, InputType.JSON, True))
+[nextpipe]   Definition: Step(solve_vroom, StepNeeds(align), StepRun(routing-pyvroom, , {}, InputType.JSON, True))
 [nextpipe]   Docstring: Solve the problem using the Vroom solver.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve_ortools, StepNeeds(align), StepRun(routing-ortools, latest, {}, InputType.JSON, True))
+[nextpipe]   Definition: Step(solve_ortools, StepNeeds(align), StepRun(routing-ortools, , {}, InputType.JSON, True))
 [nextpipe]   Docstring: Solve the problem using the OR-Tools solver.
 [nextpipe] Step:
 [nextpipe]   Definition: Step(pick_best, StepNeeds(solve_nextroute,solve_vroom,solve_ortools))

--- a/docs/examples/complex-workflow.md
+++ b/docs/examples/complex-workflow.md
@@ -60,21 +60,21 @@ class Workflow(FlowSpec):
         return clone
 
     @repeat(repetitions=2)
-    @app(app_id="routing-nextroute", instance_id="latest")
+    @app(app_id="routing-nextroute")
     @needs(predecessors=[prepare])
     @step
     def run_nextroute() -> list[dict[str, Any]]:
         """Runs the model."""
         pass
 
-    @app(app_id="routing-ortools", instance_id="latest")
+    @app(app_id="routing-ortools")
     @needs(predecessors=[convert])
     @step
     def run_ortools() -> dict[str, Any]:
         """Runs the model."""
         pass
 
-    @app(app_id="routing-pyvroom", instance_id="latest")
+    @app(app_id="routing-pyvroom")
     @needs(predecessors=[convert])
     @step
     def run_pyvroom() -> dict[str, Any]:
@@ -147,13 +147,13 @@ $ curl "https://gist.githubusercontent.com/merschformann/a90959b87d1360b604e4a9f
 [nextpipe]   Definition: Step(convert, StepNeeds(prepare))
 [nextpipe]   Docstring: Converts the data.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(run_nextroute, StepNeeds(prepare), StepRepeat(2), StepRun(routing-nextroute, latest, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(run_nextroute, StepNeeds(prepare), StepRepeat(2), StepRun(routing-nextroute, , {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(run_ortools, StepNeeds(convert), StepRun(routing-ortools, latest, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(run_ortools, StepNeeds(convert), StepRun(routing-ortools, , {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(run_pyvroom, StepNeeds(convert), StepRun(routing-pyvroom, latest, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(run_pyvroom, StepNeeds(convert), StepRun(routing-pyvroom, , {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
 [nextpipe]   Definition: Step(pick_best, StepNeeds(run_nextroute,run_ortools,run_pyvroom))

--- a/docs/examples/ensemble-workflow.md
+++ b/docs/examples/ensemble-workflow.md
@@ -27,7 +27,7 @@ from nextpipe import FlowSpec, app, log, needs, repeat, step
 
 # Define the options for the workflow
 options = nextmv.Options(
-    nextmv.Option("instance", str, "latest", "App instance to use. If not provided, app-defined is used.", False),
+    nextmv.Option("instance", str, "", "App instance to use. If not provided, app-defined is used.", False),
 )
 
 

--- a/docs/examples/ensemble-workflow.md
+++ b/docs/examples/ensemble-workflow.md
@@ -27,7 +27,7 @@ from nextpipe import FlowSpec, app, log, needs, repeat, step
 
 # Define the options for the workflow
 options = nextmv.Options(
-    nextmv.Option("instance", str, "latest", "App instance to use. Default is devint.", False),
+    nextmv.Option("instance", str, "latest", "App instance to use. If not provided, app-defined is used.", False),
 )
 
 

--- a/docs/examples/fanout-workflow.md
+++ b/docs/examples/fanout-workflow.md
@@ -114,7 +114,7 @@ $ echo '{"hello": "world!"}' | python main.py
         Calculates some statistics to put on the output as well.
         
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve, StepNeeds(fanout), StepRun(echo, devint, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(solve, StepNeeds(fanout), StepRun(echo, latest, {}, InputType.JSON, False))
 [nextpipe]   Docstring: 
         Runs the model.
         

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -101,7 +101,7 @@ def process_both(result_from_step1: dict, result_from_step2: dict):
 decorator:
 
 ```python
-@app(app_id="solver-app", instance_id="latest")
+@app(app_id="solver-app")
 @needs(predecessors=[prepare])
 @step
 def solve():
@@ -221,7 +221,7 @@ def create_scenarios(data: dict):
     ]
 
 @needs(predecessors=[create_scenarios])
-@app(app_id="solver-app", instance_id="latest")
+@app(app_id="solver-app")
 @step
 def solve():
     """Run external solver for each scenario."""
@@ -254,7 +254,7 @@ Consider the following output taken from the [basic example][basic-example]:
 [nextpipe]   Definition: Step(prepare)
 [nextpipe]   Docstring: Prepares the data.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, latest, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, , {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
 [nextpipe]   Definition: Step(enhance, StepNeeds(solve))

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -254,7 +254,7 @@ Consider the following output taken from the [basic example][basic-example]:
 [nextpipe]   Definition: Step(prepare)
 [nextpipe]   Docstring: Prepares the data.
 [nextpipe] Step:
-[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, devint, {}, InputType.JSON, False))
+[nextpipe]   Definition: Step(solve, StepNeeds(prepare), StepRun(echo, latest, {}, InputType.JSON, False))
 [nextpipe]   Docstring: Runs the model.
 [nextpipe] Step:
 [nextpipe]   Definition: Step(enhance, StepNeeds(solve))

--- a/nextpipe/__about__.py
+++ b/nextpipe/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.3.4"
+__version__ = "v0.3.5-dev.0"

--- a/nextpipe/decorators.py
+++ b/nextpipe/decorators.py
@@ -798,7 +798,7 @@ class App:
         app_id : str
             The ID of the Nextmv Application to run.
         instance_id : str, optional
-            The ID of the instance to run, uses default instance by default.
+            The ID of the instance to run. Default is defined by the app on Platform.
         input_type : InputType, optional
             The type of input to pass to the application, by default InputType.JSON.
         options : dict[str, Any], optional

--- a/nextpipe/decorators.py
+++ b/nextpipe/decorators.py
@@ -783,7 +783,7 @@ class App:
     def __init__(
         self,
         app_id: str,
-        instance_id: str = "devint",
+        instance_id: str = "",
         input_type: InputType = InputType.JSON,
         parameters: dict[str, typing.Any] = None,
         options: dict[str, typing.Any] = None,
@@ -798,7 +798,7 @@ class App:
         app_id : str
             The ID of the Nextmv Application to run.
         instance_id : str, optional
-            The ID of the instance to run, by default "devint".
+            The ID of the instance to run, uses default instance by default.
         input_type : InputType, optional
             The type of input to pass to the application, by default InputType.JSON.
         options : dict[str, Any], optional
@@ -840,7 +840,7 @@ class App:
 
 def app(
     app_id: str,
-    instance_id: str = "devint",
+    instance_id: str = "",
     parameters: dict[str, typing.Any] = None,
     options: dict[str, typing.Any] = None,
     input_type: InputType = InputType.JSON,
@@ -867,7 +867,7 @@ def app(
     app_id : str
         The ID of the application to run.
     instance_id : str
-        The ID of the instance to run. Default is "devint".
+        The ID of the instance to run. Default is defined by the app on Platform.
     options : dict[str, Any]
         The options to pass to the application. This is a dictionary of
         parameter names and values. The values must be JSON serializable.

--- a/nextpipe/flow.py
+++ b/nextpipe/flow.py
@@ -953,8 +953,9 @@ class Runner:
             app = Application(
                 client=client,
                 id=app_step.app_id,
-                default_instance_id=app_step.instance_id,
             )
+            if app_step.instance_id is not None and app_step.instance_id != "":
+                app.default_instance_id = app_step.instance_id
 
             # Run the application
             result = app.new_run_with_result(
@@ -963,6 +964,7 @@ class Runner:
             )
             run_id = result.id
             node.run_id = run_id
+            utils.log_internal(f"Finished app step {node.id} run, find it at {result.console_url}")
 
             # Return result (do not unwrap if full result is requested)
             if app_step.full_result:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.31.0",
-    "nextmv>=0.28.0",
+    "nextmv>=0.29.4",
     "dataclasses-json>=0.6.7",
 ]
 description = "Framework for Decision Pipeline modeling and execution"

--- a/tests/pipelines/complex.py
+++ b/tests/pipelines/complex.py
@@ -13,21 +13,21 @@ class Flow(FlowSpec):
         return input
 
     @repeat(repetitions=2)
-    @app(app_id="routing-nextroute", instance_id="latest")
+    @app(app_id="routing-nextroute")
     @needs(predecessors=[prepare])
     @step
     def run_nextroute():
         """Runs the model."""
         pass
 
-    @app(app_id="routing-ortools", instance_id="latest")
+    @app(app_id="routing-ortools")
     @needs(predecessors=[prepare])
     @step
     def run_ortools():
         """Runs the model."""
         pass
 
-    @app(app_id="routing-pyvroom", instance_id="latest")
+    @app(app_id="routing-pyvroom")
     @needs(predecessors=[prepare])
     @step
     def run_pyvroom():


### PR DESCRIPTION
# Description

> [!CAUTION]
> This needs a `nextmv` package release before it can be shipped. Waiting on https://github.com/nextmv-io/nextmv-py/pull/125.

Makes the `@app` decorator use the platform defined default instance ID instead of defaulting to `devint`. This allows seemingly transitioning between custom apps and marketplace apps.

## Changes

- `@app` decorator now uses platform defined default instance by default.