### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ jobs:
         python-version: ["3.10"]
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       id-token: write # This is required for trusted publishing to PyPI
     steps:
       - name: git clone ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
 
       - name: install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
         run: python -m build
 
       - name: python - publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: ./dist
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
         python-version: ["3.10", "3.14"]
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
# Description

Pins all workflow actions to their latest version via shas for improved security (avoiding supply chain attacks).

## Changes

- `actions/checkout`: `v4` → `v6.0.2` (`de0fac2e4500...`)
- `actions/setup-python`: `v5` → `v6.2.0` (`a309ff8b426b...`)
- `pypa/gh-action-pypi-publish`: `release/v1` → `v1.14.0` (`cef221092ed1...`)
